### PR TITLE
Changes for putting CSS into default <HEAD>

### DIFF
--- a/TexasExes_FormAssemblyStyle.css
+++ b/TexasExes_FormAssemblyStyle.css
@@ -3,138 +3,138 @@
 <style type="text/css">
 
   /*  Set the background color for the page */
-  .wFormWebPage{
-    background-color: #f8f9f7 !important;
+  body .wFormWebPage{
+    background-color: #f8f9f7;
   }
 
   /* Set the background color for just the form */
-  .wForm {
+  body .wForm {
     background-color: #fff;
   }
 
   /* Set the color and character for the required field marker */
-  .wForm .reqMark::after{
+  body .wForm .reqMark::after{
     content: " *";
-    color: #cb6015 !important;
+    color: #cb6015;
     font-size: 100%;
   }
 
   /* Set the correct font for field labels */
-  .wForm .preField {
+  body .wForm .preField {
     font-family: 'Rubik', sans-serif;
   }
 
   /* Set the color and border options for a container object */
-  .wFormContainer {
+  body .wFormContainer {
     background-color: #fff;
-    padding: 2em !important;
+    padding: 2em;
     border-color: #ecece7;
     border-style: solid;
     border-width: 1px;
   }
 
   /* Set the font family and styling for the form's title */
-  .wFormContainer .wFormTitle {
-    font-family: 'Sentinel A', 'Georgia', serif;
+  body .wFormContainer .wFormTitle {
+    font-family: 'Sentinel A', 'Sentinel B', 'Georgia', serif;
     font-weight: 700 !important;
-    font-style: normal !important;
+    font-style: normal;
     text-align: center;
     color: #555 !important;
   }
 
   /* Set the padding, height, and justification for the header image */
-  .wFormContainer .wFormHeader {
-    background-position: center center !important;
-    padding-top: 20px !important;
+  body .wFormContainer .wFormHeader {
+    background-position: center center;
+    padding-top: 20px;
     height: 3em;
   }
 
   /* Set the alignment and font for text sections on a form
      This requires specific styling because text sections get their own html blocks */
-  .htmlContent {
+  body .htmlContent {
     vertical-align: center;
-    font-family: 'Rubik', sans-serif !important;
+    font-family: 'Rubik', sans-serif;
   }
 
   /* Font and other options for form elements within a form container
      This affects things like labels, input boxes, and element spacing */
-  .wFormContainer .wForm {
-    padding: 1em 0em !important;
-    font-family: 'Rubik',sans-serif !important;
-    font-size: 16px !important;
-    color: #777 !important;
-    border-color: #ecede8 !important;
-    border-top-width: thin !important;
-    border-left-width: thin !important;
-    border-bottom-width: thin !important;
-    border-right-width: thin !important;
-    line-height: 1.8em !important;
+  body .wFormContainer .wForm {
+    padding: 1em 0em;
+    font-family: 'Rubik',sans-serif;
+    font-size: 16px;
+    color: #777;
+    border-color: #ecede8;
+    border-top-width: thin;
+    border-left-width: thin;
+    border-bottom-width: thin;
+    border-right-width: thin;
+    line-height: 1.8em;
   }
 
   /* Set the border around a field set form element and set the font family */
-  .wFormContainer fieldset {
+  body .wFormContainer fieldset {
     font-family: 'Rubik', sans-serif;
     border: 1px solid #ecede8;
   }
 
   /* Set the font information for a field set element's title */
-  .wFormContainer fieldset legend {
+  body .wFormContainer fieldset legend {
     font-size: 20px;
-    font-weight: 700 !important;
-    font-family: 'Sentinel A', 'Georgia', serif;
-    font-style: normal !important;
+    font-weight: 700;
+    font-family: 'Sentinel A', 'Sentinel B', 'Georgia', serif;
+    font-style: normal;
     color: #555;
     padding: 10px 8px 10px 8px;
   }
 
   /* Sets the font size when the custom teHeadlineDescription class is invoked
      This will be invoked within a text section element as you can provide inline styling and custom classes */
-  .teHeadlineDescription {
+  body .teHeadlineDescription {
     font-size: 24px;
   }
 
   /* Sets font size and padding options when custom teSectionDescription class is invoked
      This will be invoked within a text section element as you can provide inline styling and custom classes */
-  .teSectionDescription {
+  body .teSectionDescription {
     font-size: 20px;
     font-weight: bold;
-    padding-top: 1.8em !important;
+    padding-top: 1.8em;
   }
 
   /* Sets font options for user input */
-  .wForm .inputWrapper input[type=text],
-  .wForm .inputWrapper input[type=time],
-  .wForm .inputWrapper input[type=number],
-  .wForm .inputWrapper input[type=url],
-  .wForm .inputWrapper input[type=email],
-  .wForm .inputWrapper input[type=checkbox],
-  .wForm .inputWrapper input[type=password],
-  .wForm .inputWrapper textarea,
-  .wForm .inputWrapper select {
+  body .wForm .inputWrapper input[type=text],
+  body .wForm .inputWrapper input[type=time],
+  body .wForm .inputWrapper input[type=number],
+  body .wForm .inputWrapper input[type=url],
+  body .wForm .inputWrapper input[type=email],
+  body .wForm .inputWrapper input[type=checkbox],
+  body .wForm .inputWrapper input[type=password],
+  body .wForm .inputWrapper textarea,
+  body .wForm .inputWrapper select {
     max-width: 100%;
     border-radius: 2px;
     border-style: solid;
-    border-color: #ccc !important;
+    border-color: #ccc;
     border-width: 1px;
     font-family: 'Rubik',sans-serif !important;
-    color: #555;
+    color: #555 !important;
   }
 
   /* Sets the font options for the words within add a file element */
-  .wform .inputWrapper input[type=file] {
-    font-family: 'Rubik',sans-serif !important;
-    font-size: 16px !important;
+  body .wform .inputWrapper input[type=file] {
+    font-family: 'Rubik',sans-serif;
+    font-size: 16px;
   }
 
   /* Sets the style the submit button */
-  input.primaryAction {
+  body input.primaryAction {
     -webkit-appearance: none;
     background-color: #cb6015 !important;
     font-family: 'Rubik',sans-serif !important;
   }
 
   /* Sets the style for the contact information link footer text */
-  a.contactInfoLink{
+  body a.contactInfoLink{
     color: #cb6015 !important;
     font-size: 17px;
   }


### PR DESCRIPTION
We moved the CSS into a new section in FormAssembly. Instead of applying the CSS directly to each form, we are now moving the CSS into the default <HEAD> section that is applied to all forms by default. With that, we had to update the CSS because the CSS appears at the top of the <src> list when the page is rendered. The changes are styled so that our styles are not overwritten on page load.

I also needed to include `'Sentinel B'` when making font declarations. That is added, as well.